### PR TITLE
Extract common modules from async chunks as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-chunks-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/features/async-consumer.js
+++ b/test/fixtures/features/async-consumer.js
@@ -1,0 +1,9 @@
+module.exports = {
+    init() {
+        this.value = 'initial value';
+        import('./async-value').then(asyncValue => this.value = asyncValue);
+    },
+    render() {
+        return `this.value = ${this.value}`;
+    },
+};

--- a/test/fixtures/features/async-dep.js
+++ b/test/fixtures/features/async-dep.js
@@ -1,0 +1,1 @@
+module.exports = 'async';

--- a/test/fixtures/features/async-value.js
+++ b/test/fixtures/features/async-value.js
@@ -1,0 +1,6 @@
+const comp1 = require('../components/comp1');
+const comp2 = require('../components/comp2');
+const percent = require('./percent');
+const asyncDep = require('./async-dep');
+
+module.exports = `${asyncDep}Value`;


### PR DESCRIPTION
Fixes #4 by adding all async chunks to selected chunks.  This
reduces the size of async chunks significantly.  The only
downside is that if the async chunks contain modules that don't
exist in the any of the entry chunks and that would be extracted
based on the settings for the shared chunk, the shared chunk will
be larger.  Those extra modules in the shared chunk will always
be loaded regardless of whether the async chunk is actually loaded.
We will eventually add a setting to create shared chunks containing
modules that fall into situation in a followup diff.

Test Plan: npm test

Reviewers: @jacquelineawatts @jeresig 

Subscribers: @csilvers @somewhatabstract @matchu 